### PR TITLE
Fix command typo in reload supervisord section

### DIFF
--- a/EC2_setup.md
+++ b/EC2_setup.md
@@ -92,8 +92,8 @@ stderr_logfile=/var/log/supervisor/ipfs-stderr.log
 
 Reload supervisord
 
-* `sudu supervisorctl reload`
-* `sudu supervisorctl status`
+* `sudo supervisorctl reload`
+* `sudo supervisorctl status`
 
 Monitor IPFS with `tail`
 


### PR DESCRIPTION
Superuser rights are applied while run commands with `sudo ` tool, not `sudu`